### PR TITLE
fix: rename requirement.txt to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+transformers==4.49.0
+lm_eval==0.4.8
+accelerate==0.34.2
+antlr4-python3-runtime==4.11
+math_verify
+sympy
+hf_xet
+pydantic==2.10.6
+gradio
+datasets==3.2.0
+deepspeed==0.16.2
+trl==0.16.0
+tqdm==4.66.5
+peft==0.14.0


### PR DESCRIPTION
## Summary
This PR fixes the typo in the dependency file name by renaming `requirement.txt` to `requirements.txt`.

## Changes
- Renamed `requirement.txt` → `requirements.txt`
- No content changes, only filename correction

## Why
- Standard Python convention uses `requirements.txt` (plural)
- README.md already references `requirements.txt`, so this fixes the inconsistency
- Makes the project follow standard Python practices

## Testing
- Verified that the file content remains unchanged
- README.md instructions (`pip3 install -r requirements.txt`) will now work correctly

Fixes #9